### PR TITLE
Move carousel controls inside their container.

### DIFF
--- a/src/css/ptp-splash-page.css
+++ b/src/css/ptp-splash-page.css
@@ -42,10 +42,6 @@ body {
   height: 500px;
 }
 
-.carousel-control {
-  height: 550px;
-}
-
 .col-centered, .col-centered p {
     text-align: center;
     padding-bottom: 5px;

--- a/src/dust/splash.dust.html
+++ b/src/dust/splash.dust.html
@@ -95,9 +95,9 @@
             </div>
           </div>
         </div>
+        <a class="left carousel-control hidden-xs" href="#Carousel" data-slide="prev"><span class="glyphicon glyphicon-chevron-left"></span></a>
+        <a class="right carousel-control hidden-xs" href="#Carousel" data-slide="next"><span class="glyphicon glyphicon-chevron-right"></span></a>
       </div>
-      <a class="left carousel-control hidden-xs" href="#Carousel" data-slide="prev"><span class="glyphicon glyphicon-chevron-left"></span></a>
-      <a class="right carousel-control hidden-xs" href="#Carousel" data-slide="next"><span class="glyphicon glyphicon-chevron-right"></span></a>
     </div><!-- /.carousel -->
 
     <p>&nbsp;</p>


### PR DESCRIPTION
The carousel controls are absolutely positioned, which means they need to be inside the relatively positioned carousel container to work correctly if anything is added above them. This also removes some superfluous CSS that was only necessary outside the context of the container.